### PR TITLE
Tweak styles for expanded sidebar menu items.

### DIFF
--- a/_includes/sidebars/docs.html
+++ b/_includes/sidebars/docs.html
@@ -1,10 +1,7 @@
 <ul class="sidebar-nav">
     <li>{% link /getting-started/ Getting Started %}</li>
-    <li><a href="/build/" class=drop-top> Build Configuration</a>
-      <ul class="drop">
-        <li>{% link /build/recipes Recipes %}</li>
-      </ul>
-    </li>
+    <li>{% link /build/ Build Configuration %}</li>
+    <li>{% link /recipes Recipes %}</li>
     <li>{% link /assets/ Assets %}</li>
     <li>{% link /app/ Using the Probo App %}</li>
     <li>{% link /build-steps/ Build Steps %}</li>
@@ -18,7 +15,7 @@
             <li>{% link /plugins/wordpress-plugin/ WordPress Plugin %}</li>
         </ul>
     </li>
-    <li><a href="#" class=drop-top>Git Repository Integrations</a>
+    <li><a href="#" class=drop-top>Git Integrations</a>
         <ul class="drop">
             <li>{% link /git/git-integrations-overview Git Integrations Overview %}</li>
             <li>{% link /git/github/ GitHub Integration %}</li>

--- a/_stylesheets/01-utilities/_variables.scss
+++ b/_stylesheets/01-utilities/_variables.scss
@@ -6,6 +6,8 @@ $probo-purple-darkest: #33001d;
 $probo-purple-dark: #440027;
 $probo-purple: #a6548c;
 $probo-pink: lighten(#985483, 5%);
+$probo-pink-light: #efe6eb;
+$probo-pink-medium: darken(#efe6eb, 5%);
 $probo-gray-dark: #404040;
 $probo-gray-dark-medium: #525252;
 $probo-gray-medium: #7d7d7d;
@@ -57,5 +59,3 @@ $bp-larger: 1500px / 16px * 1em;
 $header-height: 70px;
 $header-line-height: 35px;
 $logo-line-height: 35px;
-
-

--- a/_stylesheets/03-molecules/_sidebars.scss
+++ b/_stylesheets/03-molecules/_sidebars.scss
@@ -65,23 +65,39 @@
         a.current {
           background: #f7f2f5;
         }
-        ul {
-          li {
-            a {
-              padding-left: 24px;
-            }
-            a.current {
-              background: #efe6eb;
-            }
-            a:before {
-              content: "\00BB \0020";
-              margin-left:-24px;
-            }
+      }
+    }
+
+    .sidebar-nav{
+      position:relative;
+
+      .drop {
+        li {
+          background: $probo-pink-light;
+          &:hover {
+            background: $probo-pink-medium;
+          }
+        }
+
+        a {
+          @include rem(margin-left, 20px);
+          border: none;
+          background: transparent;
+          padding-left: 24px;
+
+          &.current {
+            background: $probo-pink-light;
+          }
+
+          &::before {
+            content: "\00BB \0020";
+            margin-left:-24px;
           }
         }
       }
     }
   }
+
   .page-content {
     padding-bottom: 24px;
     width: 100%;
@@ -93,11 +109,6 @@
       clear: none;
     }
   }
-}
-
-
-.sidebar-nav{
-  position:relative;
 }
 
 $ease: ease;
@@ -140,7 +151,4 @@ $duration: 400ms;
   &:after {
     transform: rotate( -90deg );
   }
-}
-.wrapper #sidebar-first .open .drop-top{
-  background: #efe6eb;
 }

--- a/css/probo_docs.css
+++ b/css/probo_docs.css
@@ -7184,18 +7184,37 @@ textarea:focus {
   background: #f7f2f5;
 }
 
-.wrapper #sidebar-last ul li ul li a,
-.wrapper #sidebar-first ul li ul li a {
-  padding-left: 24px;
+.wrapper #sidebar-last .sidebar-nav,
+.wrapper #sidebar-first .sidebar-nav {
+  position: relative;
 }
 
-.wrapper #sidebar-last ul li ul li a.current,
-.wrapper #sidebar-first ul li ul li a.current {
+.wrapper #sidebar-last .sidebar-nav .drop li,
+.wrapper #sidebar-first .sidebar-nav .drop li {
   background: #efe6eb;
 }
 
-.wrapper #sidebar-last ul li ul li a:before,
-.wrapper #sidebar-first ul li ul li a:before {
+.wrapper #sidebar-last .sidebar-nav .drop li:hover,
+.wrapper #sidebar-first .sidebar-nav .drop li:hover {
+  background: #e5d6df;
+}
+
+.wrapper #sidebar-last .sidebar-nav .drop a,
+.wrapper #sidebar-first .sidebar-nav .drop a {
+  margin-left: 20px;
+  margin-left: 2rem;
+  border: none;
+  background: transparent;
+  padding-left: 24px;
+}
+
+.wrapper #sidebar-last .sidebar-nav .drop a.current,
+.wrapper #sidebar-first .sidebar-nav .drop a.current {
+  background: #efe6eb;
+}
+
+.wrapper #sidebar-last .sidebar-nav .drop a::before,
+.wrapper #sidebar-first .sidebar-nav .drop a::before {
   content: "\00BB \0020";
   margin-left: -24px;
 }
@@ -7205,10 +7224,6 @@ textarea:focus {
   width: 100%;
   float: none;
   clear: both;
-}
-
-.sidebar-nav {
-  position: relative;
 }
 
 .plus-to-minus {
@@ -7252,10 +7267,6 @@ textarea:focus {
 .open .plus-to-minus:after {
   -ms-transform: rotate(-90deg);
       transform: rotate(-90deg);
-}
-
-.wrapper #sidebar-first .open .drop-top {
-  background: #efe6eb;
 }
 
 .slide-nav {

--- a/docs/recipes.html
+++ b/docs/recipes.html
@@ -2,7 +2,7 @@
 layout: "docs"
 title: Recipes
 class: documentation
-permalink: /build/recipes/
+permalink: /recipes/
 published: true
 ---
 


### PR DESCRIPTION
It was difficult to tell what was a sub-item in the docs sidebar menu. The goal for this PR is the tweak the styles so that it is more apparent that the user is revealing sub-items when the press the plus icons.
