### PR TITLE
PB-307 Matching nav links to those on main site.

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,9 +1,33 @@
-- title: About
-  url: http://probo.ci
-  text: About
+- title: Product
+  url: http://probo.ci/product/
+  text: Product
+  secondary: product
+
+- title: About Us
+  url: http://probo.ci/about/
+  text: About Us
   secondary: about
+
+- title: Pricing
+  url: http://probo.ci/pricing/
+  text: Pricing
+  secondary: pricing
 
 - title: Blog
   url: http://blog.probo.ci/
   text: Blog
   secondary: blog
+
+- title: FAQ
+  url: http://probo.ci/faq/
+  text: FAQ
+
+- title: Docs
+  url: /
+  text: Docs
+  secondary: docs
+
+- title: Contact
+  url: http://probo.ci/contact/
+  text: Contact
+  secondary: contact

--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -3,15 +3,15 @@
 {% assign previous="" %}
 <ul class="breadcrumb">
   {% if num_parts == "0" or num_parts == "-1" %}
-  <li><a href="/">home</a> &nbsp; </li>
+  <li><a href="http://probo.ci/">home</a> &nbsp; </li>
   {% else %}
-  <li><a href="/">home</a> &#187; </li>
+  <li><a href="http://probo.ci/">home</a> &#187; </li>
 
   {% for unused in page.content limit:num_parts %}
   {% capture first_word %}{{ url_parts | truncatewords:1 | remove:"..."}}{% endcapture %}
   {% capture previous %}{{ previous }}/{{ first_word }}{% endcapture %}
 
-  <li><a href="{{previous}}">{{ first_word }}</a> &#187; </li>
+  <li>{{ first_word }} &#187; </li>
   {% capture url_parts %}{{ url_parts | remove_first:first_word }}{% endcapture %}
   {% endfor %}
   {% endif %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,7 +23,7 @@
       </ul>
     </div>
 
-    <h1 class="st"><a class="site-title" href="{{ site.baseurl }}/">
+    <h1 class="st"><a class="site-title" href="http://probo.ci/">
       <img src="/images/probo-logo-no-slogan-white.png" alt="Probo logo with name"></a></h1>
 
     <ul id="navigation">


### PR DESCRIPTION
The main navigation on the site now behaves exactly as it does on http://probo.ci/. This includes the breadcrumb 'home' link and the main logo link.