### PR TITLE
Documenting notification webhooks.

### DIFF
--- a/_data/docs-menu.yml
+++ b/_data/docs-menu.yml
@@ -17,6 +17,9 @@
     - title: Build Steps
       url: /steps
       text: Build Steps
+    - title: Notifications
+      url: /notifications
+      text: Notifications
 
 - title: Plugins
   text: Plugins

--- a/docs/build-configuration/notifications.md
+++ b/docs/build-configuration/notifications.md
@@ -1,0 +1,23 @@
+---
+layout: "docs"
+title: Notifications
+class: documentation
+permalink: /build/notifications/
+published: true
+---
+
+You can add notifications to your build by adding a notifications key to your `.probo.yaml` file. This will allow you to start getting webhooks delivered to your service when changes happen to your builds, including steps completing and builds passing or failing.
+
+## Examples
+
+{% highlight yaml %}
+notifications:
+  webhook: https://example.com/api/probo-notification
+{% endhighlight %}
+
+{% highlight yaml %}
+notifications:
+  webhook:
+    - https://example.com/api/probo-notification1
+    - https://example.com/api/probo-notification2
+{% endhighlight %}

--- a/docs/build-configuration/notifications.md
+++ b/docs/build-configuration/notifications.md
@@ -6,9 +6,13 @@ permalink: /build/notifications/
 published: true
 ---
 
-You can add notifications to your build by adding a notifications key to your `.probo.yaml` file. This will allow you to start getting webhooks delivered to your service when changes happen to your builds, including steps completing and builds passing or failing.
+Enabling notifications from Probo allows you to be automatically informed about your builds' status and completion. Currently, Probo supports webhook  `POST` notifications, but will soon support HipChat and Slack notifications as well.
 
-## Examples
+## Webhook notifications
+
+Get started with webbook notifications by adding a `notifications` key to your `.probo.yaml` file. Within this `notifications` key, add your webhook `POST` URL. You can add a single URL or multiple URLs. See the following examples for more information:
+
+### Examples
 
 {% highlight yaml %}
 notifications:


### PR DESCRIPTION
This is a first pass at documenting the notification system. We should provide examples for sending notifications to common applications, such as HipChat or Slack.