### PR TITLE
Reducing recipe data redundancy.

### DIFF
--- a/_recipes/drupal_settings_option.md
+++ b/_recipes/drupal_settings_option.md
@@ -1,5 +1,6 @@
 ---
 title: Using the Settings Options
+uid: drupal_settings_option
 ---
 
 {% highlight yaml%}

--- a/_recipes/drupal_using_plugin.md
+++ b/_recipes/drupal_using_plugin.md
@@ -1,5 +1,6 @@
 ---
 title: Using the Drupal plugin
+uid: drupal_using_plugin
 ---
 
 {% highlight yaml%}

--- a/_recipes/lamp_set_php_config_on_drupal.md
+++ b/_recipes/lamp_set_php_config_on_drupal.md
@@ -1,5 +1,6 @@
 ---
 title: Setting LAMPApp PHP Configuration Options on a Drupal Installation
+uid: lamp_set_php_config_on_drupal
 ---
 
 {% highlight yaml%}

--- a/_recipes/lamp_test_phpmysql_app.md
+++ b/_recipes/lamp_test_phpmysql_app.md
@@ -1,5 +1,6 @@
 ---
 title: Using the LAMPApp Plugin to Test a PHP/MySQL Based Application
+uid: lamp_test_phpmysql_app
 ---
 
 {% highlight yaml%}

--- a/_recipes/pantheon_example.md
+++ b/_recipes/pantheon_example.md
@@ -1,6 +1,6 @@
 ---
 title: Getting a database for a Drupal site hosted on Pantheon
-uid: pantheon
+uid: pantheon_example
 ---
 
 Be sure to substitute the name of your Pantheon site for 'YOURSITE'.

--- a/_recipes/script_site_with_database.md
+++ b/_recipes/script_site_with_database.md
@@ -1,5 +1,6 @@
 ---
 title: Developing on a site with a database
+uid: script_site_with_database
 ---
 
 Here is an example using a multi-line YAML string.

--- a/_recipes/script_using_plugin.md
+++ b/_recipes/script_using_plugin.md
@@ -1,5 +1,6 @@
 ---
 title: Using the Script plugin
+uid: script_using_plugin
 ---
 
 Add your script as a multi-line YAML string.

--- a/_recipes/shell_develop_with_database.md
+++ b/_recipes/shell_develop_with_database.md
@@ -1,5 +1,6 @@
 ---
 title: Developing on a site with a database
+uid: shell_develop_with_database
 ---
 
 {% highlight yaml %}

--- a/_recipes/shell_using_plugin.md
+++ b/_recipes/shell_using_plugin.md
@@ -1,5 +1,6 @@
 ---
 title: Using the Shell plugin
+uid: shell_using_plugin
 ---
 
 {% highlight yaml %}

--- a/_recipes/wordpress_using_plugin.md
+++ b/_recipes/wordpress_using_plugin.md
@@ -1,5 +1,6 @@
 ---
 title: Using the WordPress Plugin
+uid: wordpress_using_plugin
 ---
 
 {% highlight yaml%}

--- a/docs/plugins/drupal-plugin.md
+++ b/docs/plugins/drupal-plugin.md
@@ -47,30 +47,8 @@ The Drupal plugin provides an easy way for you to configure your Drupal build an
 
 **Using the `Drupal` plugin**
 
-{% highlight yaml%}
-assets:
-  - mydb.sql.gz
-steps:
-  - name: Probo site setup
-    plugin: Drupal
-    database: mydb.sql.gz
-    databaseGzipped: true
-    databaseUpdates: true
-    subDirectory: docroot
-    revertFeatures: true
-{% endhighlight %}
+{{ site.recipes | where: 'uid', 'drupal_using_plugin' }}
 
 **Using the Settings Options**
 
-{% highlight yaml%}
-assets:
-  - mydb.sql.gz
-steps:
-  - name: Provision Drupal
-    plugin: Drupal
-    runInstall: standard
-    settingsRequireFile: 'site-settings.php'
-    settingsAppend: |
-      $bar = 'baz';
-      $foo = 'stuff';
-{% endhighlight %}
+{{ site.recipes | where: 'uid', 'drupal_settings_option' }}

--- a/docs/plugins/lamp-plugin.md
+++ b/docs/plugins/lamp-plugin.md
@@ -48,34 +48,8 @@ The Probo [Drupal plugin](/plugins/drupal-plugin/), [WordPress plugin](/plugins/
 
 **Using the `LAMPApp` Plugin to Test a PHP/MySQL Based Application**
 
-{% highlight yaml%}
-assets:
-  - mydb.sql.gz
-steps:
-  - name: Probo site setup
-    plugin: LAMPApp
-    database: mydb.sql.gz
-    databaseName: mydb
-    databaseUser: mydbuser
-    databaseGzipped: true
-{% endhighlight %}
+{{ site.recipes | where: 'uid', 'lamp_test_phpmysql_app' }}
 
-**Setting `LAMPApp` PHP Confiugration Options on a Drupal Installation**
+**Setting `LAMPApp` PHP Configuration Options on a Drupal Installation**
 
-{% highlight yaml%}
-phpIniOptions:
-  upload_max_filesize: 25M
-  post_max_size: 25M
-  memory_limit: 256M
-assets:
-  - mydb.sql.gz
-steps:
-  - name: Probo site setup
-    plugin: Drupal
-    database: mydb.sql.gz
-    databaseGzipped: true
-    databaseUpdates: true
-    revertFeatures: true
-  - name: Generate login link
-    command: 'drush uli'
-{% endhighlight %}
+{{ site.recipes | where: 'uid', 'lamp_set_php_config_on_drupal' }}

--- a/docs/plugins/script-plugin.md
+++ b/docs/plugins/script-plugin.md
@@ -13,64 +13,8 @@ Instead of `command`, the Script plugin requires a parameter for `script`. This 
 
 ### Using the Script plugin
 
-Add your script as a multi-line YAML string.
-
-{% highlight yaml%}
-steps:
-  - plugin: Script
-    name: List Pull Request files
-    script: |
-      cd $SRC_DIR
-      files=$(ls)
-      echo "Listing all files included in this Pull Request..."
-      echo files $files
-{% endhighlight %}
-
-You can also add your script in the traditional YAML syntax. Each new line in your script is a new item in the sequence.
-
-{% highlight yaml%}
-steps:
-  - plugin: Script
-    name: List Pull Request files
-    script:
-      - cd $SRC_DIR
-      - files=$(ls)
-      - echo "Listing all files included in this Pull Request..."
-      - echo files $files
-{% endhighlight %}
+{{ site.recipes | where: 'uid', 'script_using_plugin' }}
 
 ### Developing on a site with a database:
 
-Here is an example using a multi-line YAML string.
-
-{% highlight yaml%}
-assets:
-  - dev.sql.gz
-steps:
-  - plugin: Script
-    name: List Pull Request files
-    script: |
-      gunzip -c $ASSET_DIR/dev.sql.gz | `mysql foo`
-      rm $ASSET_DIR/dev.sql.gz
-      cd $SRC_DIR
-      files=$(ls)
-      echo "Listing all files included in this Pull Request..."
-      echo files $files
-{% endhighlight %}
-
-Here is an example using traditional YAML syntax.
-
-{% highlight yaml%}
-assets:
-  - dev.sql.gz
-steps:
-  - plugin: Script
-    name: List Pull Request files
-    script:
-      - gunzip -c $ASSET_DIR/dev.sql.gz | `mysql foo`
-      - rm $ASSET_DIR/dev.sql.gz
-      - cd $SRC_DIR
-      - files=$(ls)
-      - echo "Listing all files included in this Pull Request..."
-      - echo files $files
-{% endhighlight %}
+{{ site.recipes | where: 'uid', 'script_site_with_database' }}

--- a/docs/plugins/shell-plugin.md
+++ b/docs/plugins/shell-plugin.md
@@ -13,26 +13,8 @@ You will need to include a `name` for each `command` since you can only declare 
 
 **Using the `Shell` plugin**
 
-{% highlight yaml%}
-steps:
-  - name: Run behat tests
-    plugin: Shell
-    command: 'cd tests ; composer install ; bin/behat'
-  - name: Another example test with default Shell plugin
-    command: 'echo "Hello World!"'
-{% endhighlight %}
+{{ site.recipes | where: 'uid', 'shell_using_plugin' }}
 
 **Developing on a site with a database**
 
-{% highlight yaml%}
-assets:
-  - dev.sql.gz
-steps:
-  - name: Import the database
-    plugin: Shell
-    command: 'gunzip -c $ASSET_DIR/dev.sql.gz | `mysql foo` ; rm $ASSET_DIR/dev.sql.gz'
-  - name: Move code in place
-    command: 'mv $SRC_DIR /var/www/foo/code'
-  - name: Run behat tests
-    command: 'cd /var/www/foo/code/tests ; composer install ; bin/behat'
-{% endhighlight %}
+{{ site.recipes | where: 'uid', 'shell_develop_with_database' }}

--- a/docs/plugins/wordpress-plugin.md
+++ b/docs/plugins/wordpress-plugin.md
@@ -38,19 +38,4 @@ WordPress core and plugins generally prefer absolute URLs for links and images i
 
 **Using the Wordpress plugin**
 
-{% highlight yaml%}
- assets:
-  - dev.sql.gz
-  steps:
-  - name: Site setup
-    plugin: WordPressApp
-    database: dev.sql.gz
-    databaseName: wordpress
-    databaseGzipped: true
-    subDirectory: code
-    devDomain: example.com
-    devHome: example.com/home
-  - name: Flush the cache
-    plugin: WordPressApp
-    flushCaches: true
-{% endhighlight %}
+{{ site.recipes | where: 'uid', 'wordpress_using_plugin' }}

--- a/docs/tutorials/install-profile-quickstart.md
+++ b/docs/tutorials/install-profile-quickstart.md
@@ -45,8 +45,8 @@ steps:
 
 {% highlight yaml %}
 git add .probo.yaml  
-git commit -m"Adding .probo.yaml."  
-git push -u origin probo-build   
+git commit -m "Adding .probo.yaml."  
+git push -u origin probo-build
 {% endhighlight %}
 
 <img src='/images/git-create-branch.gif' alt='Add your Probo.CI Configuration' class='docs-gif'>

--- a/docs/tutorials/pantheon.md
+++ b/docs/tutorials/pantheon.md
@@ -47,4 +47,4 @@ steps:
 
 Now that Probo has downloaded your site's database from Pantheon it can continue with other necessary steps to build your site. The Terminus steps also cooperate with Probo's Drupal plugin. Here's an example of what that looks like:
 
-{{ site.recipes | where: 'uid', 'pantheon' }}
+{{ site.recipes | where: 'uid', 'pantheon_example' }}


### PR DESCRIPTION
I noticed that I had multiple copies of given `.probo.yaml` recipes – one in the recipes collection, and one wherever that recipe appeared in the docs (tutorials, plugin pages). These changes reuse the data from the recipes collection so that if we update there, it updates everywhere.