### PR TITLE
Trying to get rid of ruby errors preventing builds

### DIFF
--- a/.probo.yaml
+++ b/.probo.yaml
@@ -15,7 +15,7 @@ steps:
     script:
       - apt-get install -y ruby2.2 ruby2.2-dev
       - update-alternatives --config ruby
-      - gem install bundler -v 1.7.9
+      - gem install bundler
   - name: Install Jekyll Dependencies
     plugin: Script
     script:


### PR DESCRIPTION
Error: 

$ mkdir -p /src
$ cd /src
$ cd /src
$ bundle install --path vendor/bundle
Don't run Bundler as root. Bundler can ask for sudo if it is needed, and
installing your bundle as root will break this application for all non-root
users on this machine.
Your Ruby version is 2.2.7, but your Gemfile specified 2.2.2

& 

$ mkdir -p /src
$ cd /src
$ locale-gen en_US.UTF-8
Generating locales...
  en_US.UTF-8... done
Generation complete.
$ LC_ALL=en_US.UTF-8
$ LANG=en_US.UTF-8
$ LANGUAGE=en_US.UTF-8
$ bundle exec jekyll build --destination=/var/www/html
Your Ruby version is 2.2.7, but your Gemfile specified 2.2.2

