### PR TITLE
Adding .htaccess file.

### DIFF
--- a/htaccess
+++ b/htaccess
@@ -1,5 +1,5 @@
 ---
-layout: none
+layout: null
 permalink: .htaccess
 ---
 # Protect files and directories from prying eyes.

--- a/htaccess
+++ b/htaccess
@@ -1,0 +1,58 @@
+---
+layout: none
+permalink: .htaccess
+---
+# Protect files and directories from prying eyes.
+<FilesMatch "\.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock))$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$">
+  <IfModule mod_authz_core.c>
+    Require all denied
+  </IfModule>
+  <IfModule !mod_authz_core.c>
+    Order allow,deny
+  </IfModule>
+</FilesMatch>
+
+# Don't show directory listings for URLs which map to a directory.
+Options -Indexes
+
+# Set the default handler.
+DirectoryIndex index.php index.html index.htm
+
+# Add correct encoding for SVGZ.
+AddType image/svg+xml svg svgz
+AddEncoding gzip svgz
+
+# Set browser caching
+# ------------------------------------------------------------------------------
+<IfModule mod_expires.c>
+  # Enable expirations
+  ExpiresActive On
+  # Images
+  ExpiresByType image/jpg "access 1 year"
+  ExpiresByType image/jpeg "access 1 year"
+  ExpiresByType image/gif "access 1 year"
+  ExpiresByType image/png "access 1 year"
+  # CSS
+  ExpiresByType text/css "access 1 month"
+  # HTML
+  ExpiresByType text/html "access 1 month"
+  # PDF
+  ExpiresByType application/pdf "access 1 month"
+  # JS
+  ExpiresByType text/x-javascript "access 1 month"
+  # Flash
+  ExpiresByType application/x-shockwave-flash "access 1 month"
+  # Favicon
+  ExpiresByType image/x-icon "access 1 year"
+  # Default directive
+  ExpiresDefault "access 1 month"
+</IfModule>
+# End caching block
+
+# Various header fixes.
+<IfModule mod_headers.c>
+  # Disable content sniffing, since it's an attack vector.
+  Header always set X-Content-Type-Options nosniff
+  # Disable Proxy header, since it's an attack vector.
+  RequestHeader unset Proxy
+</IfModule>


### PR DESCRIPTION
Found that we had no .htaccess file on the jekyll sites today. Found this article that said this is a workaround.

http://newbieonruby.com/jekyll-include-htaccess/

I added the file manually and ran some performance tests and it fixed some issues with expires headers.