### PR TITLE
PB-575: Replace plugin tables with rows.

### DIFF
--- a/_plugins/details.rb
+++ b/_plugins/details.rb
@@ -1,0 +1,24 @@
+# Source: https://gist.github.com/towbi/a67fda47e075d2b7fa4764bb42605063#file-details_tag-rb
+
+module Jekyll
+  module Tags
+    class DetailsTag < Liquid::Block
+
+      def initialize(tag_name, markup, tokens)
+        super
+        @caption = markup
+      end
+
+      def render(context)
+        site = context.registers[:site]
+        converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
+        caption = converter.convert(@caption).gsub(/<\/?p[^>]*>/, '').chomp
+        body = converter.convert(super(context))
+        "<details><summary class=\"button button--inverse button-sm\">#{caption}</summary>#{body}</details>"
+      end
+
+    end
+  end
+end
+
+Liquid::Template.register_tag('details', Jekyll::Tags::DetailsTag)

--- a/_plugins/details.rb
+++ b/_plugins/details.rb
@@ -22,3 +22,4 @@ module Jekyll
 end
 
 Liquid::Template.register_tag('details', Jekyll::Tags::DetailsTag)
+ 

--- a/_plugins/details.rb
+++ b/_plugins/details.rb
@@ -14,7 +14,7 @@ module Jekyll
         converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
         caption = converter.convert(@caption).gsub(/<\/?p[^>]*>/, '').chomp
         body = converter.convert(super(context))
-        "<details><summary class=\"button button--inverse button-sm\">#{caption}</summary>#{body}</details>"
+        "<details class=\"option-example\"><summary class=\"button button--inverse button-sm\">#{caption}<i class=\"fa fa-angle-down\" aria-hidden=\"true\"></i></summary>#{body}</details>"
       end
 
     end

--- a/_plugins/option.rb
+++ b/_plugins/option.rb
@@ -1,0 +1,16 @@
+module Jekyll
+  module Tags
+    class Option < Liquid::Block
+
+      def render(context)
+        site = context.registers[:site]
+        converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
+        content = converter.convert(super(context))
+        "<li class=\"option-list__item\">#{content}</li>"
+      end
+
+    end
+  end
+end
+
+Liquid::Template.register_tag('option', Jekyll::Tags::Option)

--- a/_plugins/option.rb
+++ b/_plugins/option.rb
@@ -6,7 +6,7 @@ module Jekyll
         site = context.registers[:site]
         converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
         content = converter.convert(super(context))
-        "<li class=\"option-list__item\">#{content}</li>"
+        "<li class=\"striped-list__item\">#{content}</li>"
       end
 
     end

--- a/_plugins/option_list.rb
+++ b/_plugins/option_list.rb
@@ -6,7 +6,7 @@ module Jekyll
         site = context.registers[:site]
         converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
         content = converter.convert(super(context))
-        "<ul class=\"option-list\">#{content}</ul>"
+        "<ul class=\"striped-list\">#{content}</ul>"
       end
 
     end

--- a/_plugins/option_list.rb
+++ b/_plugins/option_list.rb
@@ -1,0 +1,16 @@
+module Jekyll
+  module Tags
+    class OptionList < Liquid::Block
+
+      def render(context)
+        site = context.registers[:site]
+        converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
+        content = converter.convert(super(context))
+        "<ul class=\"option-list\">#{content}</ul>"
+      end
+
+    end
+  end
+end
+
+Liquid::Template.register_tag('option_list', Jekyll::Tags::OptionList)

--- a/_stylesheets/02-atoms/_all.scss
+++ b/_stylesheets/02-atoms/_all.scss
@@ -4,3 +4,4 @@
 @import 'inputs';
 @import 'logos';
 @import 'figure';
+@import 'option-example';

--- a/_stylesheets/02-atoms/_option-example.scss
+++ b/_stylesheets/02-atoms/_option-example.scss
@@ -16,4 +16,11 @@
       transform: rotate(-180deg);
     }
   }
+
+  .highlight {
+    // border: 1px dashed $probo-pale-darker;
+    // box-shadow: inset 1px 1px 5px 0 $probo-pale-dark;
+    margin-top: 1rem;
+    margin-bottom: -1.4rem;
+  }
 }

--- a/_stylesheets/02-atoms/_option-example.scss
+++ b/_stylesheets/02-atoms/_option-example.scss
@@ -1,0 +1,19 @@
+.option-example {
+  > summary {
+    list-style: none;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+  }
+
+  i {
+    margin-left: 1rem;
+  }
+
+  &[open] {
+    i {
+      transform: rotate(-180deg);
+    }
+  }
+}

--- a/_stylesheets/02-atoms/_option-example.scss
+++ b/_stylesheets/02-atoms/_option-example.scss
@@ -18,9 +18,9 @@
   }
 
   .highlight {
-    // border: 1px dashed $probo-pale-darker;
-    // box-shadow: inset 1px 1px 5px 0 $probo-pale-dark;
-    margin-top: 1rem;
+    border: 1px solid darken($probo-pale-dark, 5%);
+    box-shadow: inset 1px 1px 5px 0 $probo-pale-dark;
+    margin-top: 1.4rem;
     margin-bottom: -1.4rem;
   }
 }

--- a/_stylesheets/02-atoms/_typography.scss
+++ b/_stylesheets/02-atoms/_typography.scss
@@ -26,24 +26,6 @@ code.highlighter-rouge {
 }
 
 .body-text {
-  font-family: $sans-serif;
-  font-weight: 100;
-
-  .option-list {
-    padding-left: 0;
-    list-style: none;
-
-    &__item {
-      padding: 3rem 1.5rem;
-      margin: 0 -1.5rem;
-      outline: 1px solid $probo-pale-dark;
-
-      &:nth-of-type(even) {
-        background-color: $probo-pale-medium;
-      }
-    }
-  }
-
   h3 {
     margin-top: 4rem;
     margin-bottom: 0;
@@ -55,5 +37,9 @@ code.highlighter-rouge {
 
   pre {
     margin-bottom: 0;
+  }
+
+  .striped-list {
+    margin: 0 -1.5rem;
   }
 }

--- a/_stylesheets/02-atoms/_typography.scss
+++ b/_stylesheets/02-atoms/_typography.scss
@@ -24,3 +24,8 @@ p.subhead {
 code.highlighter-rouge {
   background: $probo-pale-medium;
 }
+
+.body-text {
+  font-family: $sans-serif;
+  font-weight: 100;
+}

--- a/_stylesheets/02-atoms/_typography.scss
+++ b/_stylesheets/02-atoms/_typography.scss
@@ -28,4 +28,32 @@ code.highlighter-rouge {
 .body-text {
   font-family: $sans-serif;
   font-weight: 100;
+
+  .option-list {
+    padding-left: 0;
+    list-style: none;
+
+    &__item {
+      padding: 3rem 1.5rem;
+      margin: 0 -1.5rem;
+      outline: 1px solid $probo-pale-dark;
+
+      &:nth-of-type(even) {
+        background-color: $probo-pale-medium;
+      }
+    }
+  }
+
+  h3 {
+    margin-top: 4rem;
+    margin-bottom: 0;
+  }
+
+  p {
+    margin: 1.5rem 0;
+  }
+
+  pre {
+    margin-bottom: 0;
+  }
 }

--- a/css/probo.css
+++ b/css/probo.css
@@ -3457,8 +3457,10 @@ body{
   -moz-osx-font-smoothing:grayscale; }
 
 .body-text{
-  font-family:"Martel", serif;
-  line-height:1.65; }
+  font-size:1.8rem;
+  font-family:"sofia-pro", sans-serif;
+  line-height:1.65;
+  font-weight:100; }
 
 a{
   color:#0055a4;
@@ -3698,34 +3700,34 @@ form textarea, .form__input--small{
   color:#7d7d7d;
   background-color:#f5f5f5;
   max-width:100%; }
-  .form__input:active, form input[type="text"]:active,
-  form input[type="email"]:active,
-  form input[type="date"]:active,
-  form input[type="datetime"]:active,
-  form input[type="datetime-local"]:active,
-  form input[type="month"]:active,
-  form input[type="number"]:active,
-  form input[type="range"]:active,
-  form input[type="search"]:active,
-  form input[type="tel"]:active,
-  form input[type="time"]:active,
-  form input[type="url"]:active,
-  form input[type="week"]:active,
-  form input[type="password"]:active,
-  form textarea:active, .form__input--small:active, .form__input:focus, form input[type="text"]:focus,
-  form input[type="email"]:focus,
-  form input[type="date"]:focus,
-  form input[type="datetime"]:focus,
-  form input[type="datetime-local"]:focus,
-  form input[type="month"]:focus,
-  form input[type="number"]:focus,
-  form input[type="range"]:focus,
-  form input[type="search"]:focus,
-  form input[type="tel"]:focus,
-  form input[type="time"]:focus,
-  form input[type="url"]:focus,
-  form input[type="week"]:focus,
-  form input[type="password"]:focus,
+  .form__input:active, form input:active[type="text"],
+  form input:active[type="email"],
+  form input:active[type="date"],
+  form input:active[type="datetime"],
+  form input:active[type="datetime-local"],
+  form input:active[type="month"],
+  form input:active[type="number"],
+  form input:active[type="range"],
+  form input:active[type="search"],
+  form input:active[type="tel"],
+  form input:active[type="time"],
+  form input:active[type="url"],
+  form input:active[type="week"],
+  form input:active[type="password"],
+  form textarea:active, .form__input--small:active, .form__input:focus, form input:focus[type="text"],
+  form input:focus[type="email"],
+  form input:focus[type="date"],
+  form input:focus[type="datetime"],
+  form input:focus[type="datetime-local"],
+  form input:focus[type="month"],
+  form input:focus[type="number"],
+  form input:focus[type="range"],
+  form input:focus[type="search"],
+  form input:focus[type="tel"],
+  form input:focus[type="time"],
+  form input:focus[type="url"],
+  form input:focus[type="week"],
+  form input:focus[type="password"],
   form textarea:focus, .form__input--small:focus{
     background-color:#f7f7f7;
     outline:none; }
@@ -4292,3 +4294,12 @@ select,
   font-family:sans-serif;
   color:#440027;
   padding:2px 0; }
+
+.striped-list{
+  padding-left:0;
+  list-style:none; }
+  .striped-list__item{
+    padding:3rem 1.5rem;
+    outline:1px solid #ebebeb; }
+    .striped-list__item:nth-of-type(even){
+      background-color:#f5f5f5; }

--- a/css/probo.css
+++ b/css/probo.css
@@ -3379,13 +3379,12 @@ th{
   margin-bottom:24px; }
   .table th,
   .table td{
-    padding:8px;
-    line-height:24px;
+    padding:10px;
     text-align:left;
     vertical-align:top;
     border-top:1px solid #ebebeb; }
   .table th{
-    font-weight:bold; }
+    font-weight:700; }
   .table thead th{
     vertical-align:bottom; }
   .table caption + thead tr:first-child th,
@@ -3402,7 +3401,7 @@ th{
 
 .table-condensed th,
 .table-condensed td{
-  padding:4px 5px; }
+  padding:5px; }
 
 .table-bordered{
   border:1px solid #ebebeb;
@@ -3422,11 +3421,11 @@ th{
 
 .table-striped tbody > tr:nth-child(odd) > td,
 .table-striped tbody > tr:nth-child(odd) > th{
-  background-color:#f8f8f8; }
+  background-color:#f7f7f7; }
 
 .table-hover tbody tr:hover > td,
 .table-hover tbody tr:hover > th{
-  background-color:#f8f8f8; }
+  background-color:#f7f7f7; }
 
 table td[class*="span"],
 table th[class*="span"],
@@ -3698,8 +3697,7 @@ form textarea, .form__input--small{
   border:1px solid #c8c8c8;
   color:#7d7d7d;
   background-color:#f5f5f5;
-  max-width:100%;
-  border-radius:24px; }
+  max-width:100%; }
   .form__input:active, form input[type="text"]:active,
   form input[type="email"]:active,
   form input[type="date"]:active,

--- a/css/probo_docs.css
+++ b/css/probo_docs.css
@@ -7545,6 +7545,11 @@ code.highlighter-rouge {
   background: #f5f5f5;
 }
 
+.body-text {
+  font-family: "sofia-pro", sans-serif;
+  font-weight: 100;
+}
+
 input[type="text"],
 input[type="email"],
 input[type="date"],

--- a/css/probo_docs.css
+++ b/css/probo_docs.css
@@ -7654,6 +7654,11 @@ figure {
           transform: rotate(-180deg);
 }
 
+.option-example .highlight {
+  margin-top: 1rem;
+  margin-bottom: -1.4rem;
+}
+
 /*!
 Chosen, a Select Box Enhancer for jQuery and Prototype
 by Patrick Filler for Harvest, http://getharvest.com

--- a/css/probo_docs.css
+++ b/css/probo_docs.css
@@ -7550,6 +7550,34 @@ code.highlighter-rouge {
   font-weight: 100;
 }
 
+.body-text .option-list {
+  padding-left: 0;
+  list-style: none;
+}
+
+.body-text .option-list__item {
+  padding: 3rem 1.5rem;
+  margin: 0 -1.5rem;
+  outline: 1px solid #ebebeb;
+}
+
+.body-text .option-list__item:nth-of-type(even) {
+  background-color: #f5f5f5;
+}
+
+.body-text h3 {
+  margin-top: 4rem;
+  margin-bottom: 0;
+}
+
+.body-text p {
+  margin: 1.5rem 0;
+}
+
+.body-text pre {
+  margin-bottom: 0;
+}
+
 input[type="text"],
 input[type="email"],
 input[type="date"],

--- a/css/probo_docs.css
+++ b/css/probo_docs.css
@@ -7655,7 +7655,9 @@ figure {
 }
 
 .option-example .highlight {
-  margin-top: 1rem;
+  border: 1px solid #dedede;
+  box-shadow: inset 1px 1px 5px 0 #ebebeb;
+  margin-top: 1.4rem;
   margin-bottom: -1.4rem;
 }
 

--- a/css/probo_docs.css
+++ b/css/probo_docs.css
@@ -7545,26 +7545,6 @@ code.highlighter-rouge {
   background: #f5f5f5;
 }
 
-.body-text {
-  font-family: "sofia-pro", sans-serif;
-  font-weight: 100;
-}
-
-.body-text .option-list {
-  padding-left: 0;
-  list-style: none;
-}
-
-.body-text .option-list__item {
-  padding: 3rem 1.5rem;
-  margin: 0 -1.5rem;
-  outline: 1px solid #ebebeb;
-}
-
-.body-text .option-list__item:nth-of-type(even) {
-  background-color: #f5f5f5;
-}
-
 .body-text h3 {
   margin-top: 4rem;
   margin-bottom: 0;
@@ -7576,6 +7556,10 @@ code.highlighter-rouge {
 
 .body-text pre {
   margin-bottom: 0;
+}
+
+.body-text .striped-list {
+  margin: 0 -1.5rem;
 }
 
 input[type="text"],

--- a/css/probo_docs.css
+++ b/css/probo_docs.css
@@ -7637,6 +7637,23 @@ figure {
   margin: 0;
 }
 
+.option-example > summary {
+  list-style: none;
+}
+
+.option-example > summary::-webkit-details-marker {
+  display: none;
+}
+
+.option-example i {
+  margin-left: 1rem;
+}
+
+.option-example[open] i {
+  -webkit-transform: rotate(-180deg);
+          transform: rotate(-180deg);
+}
+
 /*!
 Chosen, a Select Box Enhancer for jQuery and Prototype
 by Patrick Filler for Harvest, http://getharvest.com

--- a/docs/plugins/drupal-plugin.md
+++ b/docs/plugins/drupal-plugin.md
@@ -18,21 +18,21 @@ See the <a href="#drupal-plugin-examples" title="Probo Drupal Plugin Examples">P
 ### `makeFile` {string}
 The name of the [Drush make file](http://docs.drush.org/en/7.x/make/) to run to generate the install directory.
 {% details Example %}
-  {% highlight yaml%}
-    # Use a file in your docroot
-    steps:
-      - name: Specify make file
-        plugin: Drupal
-        makeFile: example.make
+{% highlight yaml%}
+# Use a file in your docroot
+steps:
+  - name: Specify make file
+    plugin: Drupal
+    makeFile: example.make
 
-    # Use an uploaded asset
-    assets:
-      - probo-specific.make
-    steps:
-      - name: Specify make file
-        plugin: Drupal
-        makeFile: $ASSET_DIR/probo-specific.make
-  {% endhighlight %}
+# Use an uploaded asset
+assets:
+  - probo-specific.make
+steps:
+  - name: Specify make file
+    plugin: Drupal
+    makeFile: $ASSET_DIR/probo-specific.make
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -40,12 +40,12 @@ The name of the [Drush make file](http://docs.drush.org/en/7.x/make/) to run to 
 ### `makeForceComplete` {boolean}
 Whether to use the `--force-complete` option for `drush make`. Defaults to `true`.
 {% details Example %}
-  {% highlight yaml%}
-    steps:
-      - name: Do not force make file completion
-        plugin: Drupal
-        makeForceComplete: false
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Do not force make file completion
+    plugin: Drupal
+    makeForceComplete: false
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -53,9 +53,9 @@ Whether to use the `--force-complete` option for `drush make`. Defaults to `true
 ### `makeArgs` {array}
 A set of parameters to concatenate onto the `drush make` command.
 {% details Example %}
-  {% highlight yaml%}
+{% highlight yaml%}
 
-  {% endhighlight %}
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -63,9 +63,9 @@ A set of parameters to concatenate onto the `drush make` command.
 ### `profileName` {string}
 The profile name used in creating a symlink to this directory if a Drush make file is specified with the [`makeFile`](#makefile-string) option. Used to select the profile to install if the [`runInstall`](#runinstall-boolean) option is selected.
 {% details Example %}
-  {% highlight yaml%}
+{% highlight yaml%}
 
-  {% endhighlight %}
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -73,9 +73,9 @@ The profile name used in creating a symlink to this directory if a Drush make fi
 ### `runInstall` {boolean}
 If set, run `drush site-install` to perform a fresh install of the site using the [`profileName`](#profilename-string) as the install profile and allowing the [`installArgs`](#installargs-string) option to configure the install.
 {% details Example %}
-  {% highlight yaml%}
+{% highlight yaml%}
 
-  {% endhighlight %}
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -83,9 +83,9 @@ If set, run `drush site-install` to perform a fresh install of the site using th
 ### `installArgs` {string}
 A set of parameters to concatenate onto the `drush site-install` command if the [`runInstall`](#runinstall-string) option is set. Defaults to ''.
 {% details Example %}
-  {% highlight yaml%}
+{% highlight yaml%}
 
-  {% endhighlight %}
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -93,12 +93,12 @@ A set of parameters to concatenate onto the `drush site-install` command if the 
 ### `siteFolder` {string}
 Specifies the site folder to use for this build (the folder within the Drupal `sites` folder). Defaults to `default`.
 {% details Example %}
-  {% highlight yaml%}
-    steps:
-      - name: Specify non-default site
-        plugin: Drupal
-        siteFolder: blog
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Specify non-default site
+    plugin: Drupal
+    siteFolder: blog
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -106,9 +106,9 @@ Specifies the site folder to use for this build (the folder within the Drupal `s
 ### `subDirectory` {string}
 The path to your docroot if it is a subdirectory of your git repository.
 {% details Example %}
-  {% highlight yaml%}
+{% highlight yaml%}
 
-  {% endhighlight %}
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 {% endoption_list %}
@@ -120,14 +120,14 @@ The path to your docroot if it is a subdirectory of your git repository.
 ### `database` {string}
 The file name of the database to import if specified. Note that this database must be added to the assets array separately.
 {% details Example %}
-  {% highlight yaml%}
-  assets:
-    - mydb.sql.gz
-  steps:
-    - name: Import database
-      plugin: Drupal
-      database: mydb.sql.gz
-  {% endhighlight %}
+{% highlight yaml%}
+assets:
+  - mydb.sql.gz
+steps:
+  - name: Import database
+    plugin: Drupal
+    database: mydb.sql.gz
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -136,12 +136,12 @@ The file name of the database to import if specified. Note that this database mu
 Whether the database was sent gzipped and whether it should therefore be gunzipped before importing.
 
 {% details Example %}
-  {% highlight yaml%}
-  steps:
-    - name: Unzip database
-      plugin: Drupal
-      databaseGzipped: true
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Unzip database
+    plugin: Drupal
+    databaseGzipped: true
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -150,12 +150,12 @@ Whether the database was sent gzipped and whether it should therefore be gunzipp
 Whether the database was sent bzipped and whether it should therefore be bunzipped before importing.
 
 {% details Example %}
-  {% highlight yaml%}
-  steps:
-    - name: Unzip database
-      plugin: Drupal
-      databaseBzipped: true
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Unzip database
+    plugin: Drupal
+    databaseBzipped: true
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 {% endoption_list %}
@@ -168,21 +168,21 @@ Whether the database was sent bzipped and whether it should therefore be bunzipp
 ### `settingsRequireFile` {string}
 A file to require at the end of settings.php. This option helps you to avoid checking settings.php into your repository.
 {% details Example %}
-  {% highlight yaml%}
-    # Require checked in settings
-    steps:
-      - name: Require Probo-specific site settings
-        plugin: Drupal
-        settingsRequireFile: sites/default/probo-settings.php
+{% highlight yaml%}
+# Require checked in settings
+steps:
+  - name: Require Probo-specific site settings
+    plugin: Drupal
+    settingsRequireFile: sites/default/probo-settings.php
 
-    # Use an uploaded asset
-    assets:
-      - probo-settings.php
-    steps:
-      - name: Require Probo-specific site settings
-        plugin: Drupal
-        settingsRequireFile: $ASSET_DIR/probo-settings.php
-  {% endhighlight %}
+# Use an uploaded asset
+assets:
+  - probo-settings.php
+steps:
+  - name: Require Probo-specific site settings
+    plugin: Drupal
+    settingsRequireFile: $ASSET_DIR/probo-settings.php
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -190,14 +190,14 @@ A file to require at the end of settings.php. This option helps you to avoid che
 ### `settingsAppend` {string}
 Specify a snippet, such as a variable, to append to the end of the settings.php file.
 {% details Example %}
-  {% highlight yaml%}
-    steps:
-      - name: Append to settings.php
-        plugin: Drupal
-        settingsAppend: |
-          $bar = 'baz';
-          $foo = 'stuff';
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Append to settings.php
+    plugin: Drupal
+    settingsAppend: |
+      $bar = 'baz';
+      $foo = 'stuff';
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 {% endoption_list %}
@@ -209,12 +209,12 @@ Specify a snippet, such as a variable, to append to the end of the settings.php 
 ### `drupalVersion` {integer}
 Specifies which version of Drupal you are using so that the appropriate commands can be run. For example, if you specify "8" the [`clearCaches`](#clearcaches-boolean) option will run `drush cache-rebuild`. Defaults to 7. Accepts the integer values 6, 7, or 8.
 {% details Example %}
-  {% highlight yaml%}
-    steps:
-      - name: Set Drupal version
-        plugin: Drupal
-        drupalVersion: 8
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Set Drupal version
+    plugin: Drupal
+    drupalVersion: 8
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -222,12 +222,12 @@ Specifies which version of Drupal you are using so that the appropriate commands
 ### `databaseUpdates` {boolean}
 Determines whether to run `drush updb` after the build is finished.
 {% details Example %}
-  {% highlight yaml%}
-    steps:
-      - name: Run database updates
-        plugin: Drupal
-        databaseUpdates: true
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Run database updates
+    plugin: Drupal
+    databaseUpdates: true
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -235,12 +235,12 @@ Determines whether to run `drush updb` after the build is finished.
 ### `clearCaches` {boolean}
 Whether to clear all caches using `drush cc all` after the build is finished. Pair with the [`drupalVersion`](#drupalversion-integer) option to ensure the proper command is run for your version of Drupal. Defaults to true.
 {% details Example %}
-  {% highlight yaml%}
-    steps:
-      - name: Clear caches
-        plugin: Drupal
-        clearCaches: true
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Clear caches
+    plugin: Drupal
+    clearCaches: true
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -248,12 +248,12 @@ Whether to clear all caches using `drush cc all` after the build is finished. Pa
 ### `revertFeatures` {boolean}
 Whether to revert features using `drush fra` after the build is finished. To use this option, your site must have the [Features module](https://www.drupal.org/project/features) installed.
 {% details Example %}
-  {% highlight yaml%}
-    steps:
-      - name: Revert features
-        plugin: Drupal
-        revertFeatures: true
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Revert features
+    plugin: Drupal
+    revertFeatures: true
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -261,12 +261,12 @@ Whether to revert features using `drush fra` after the build is finished. To use
 ### `fileProxy` {string}
 Installs and enables the [Stage File Proxy module](https://www.drupal.org/project/stage_file_proxy) to retrieve public and/or private files from another instance of the site such as production or development. Enter the protocol and fully qualified domain here.
 {% details Example %}
-  {% highlight yaml%}
-    steps:
-      - name: Proxy site files
-        plugin: Drupal
-        fileProxy: https://example.com
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Proxy site files
+    plugin: Drupal
+    fileProxy: https://example.com
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 {% endoption_list %}

--- a/docs/plugins/drupal-plugin.md
+++ b/docs/plugins/drupal-plugin.md
@@ -111,7 +111,53 @@ The path to your docroot if it is a subdirectory of your git repository.
   {% endhighlight %}
 {% enddetails %}
 {% endoption %}
+{% endoption_list %}
 
+## Database Configuration
+
+{% option_list %}
+{% option %}
+### `database` {string}
+The file name of the database to import if specified. Note that this database must be added to the assets array separately.
+{% details Example %}
+  {% highlight yaml%}
+  assets:
+    - mydb.sql.gz
+  steps:
+    - name: Import database
+      plugin: Drupal
+      database: mydb.sql.gz
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `databaseGzipped` {boolean}
+Whether the database was sent gzipped and whether it should therefore be gunzipped before importing.
+
+{% details Example %}
+  {% highlight yaml%}
+  steps:
+    - name: Unzip database
+      plugin: Drupal
+      databaseGzipped: true
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `databaseBzipped` {boolean}
+Whether the database was sent bzipped and whether it should therefore be bunzipped before importing.
+
+{% details Example %}
+  {% highlight yaml%}
+  steps:
+    - name: Unzip database
+      plugin: Drupal
+      databaseBzipped: true
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
 {% endoption_list %}
 
 ## Settings.php Options

--- a/docs/plugins/drupal-plugin.md
+++ b/docs/plugins/drupal-plugin.md
@@ -5,7 +5,7 @@ class: documentation
 permalink: /plugins/drupal-plugin/
 published: true
 ---
-The Probo Drupal plugin provides an easy way to set Drupal site configuration options in a Probo Build and quickly integrate a Drupal website's repository. To use the Probo Drupal plugin you must declare `plugin: Drupal` in your `.probo.yaml` file. The Drupal plugin's parameters can automate some steps specific to Drupal such as reverting features, running database updates, clearing caches, or performing other build configuration steps. 
+The Probo Drupal plugin provides an easy way to set Drupal site configuration options in a Probo Build and quickly integrate a Drupal website's repository. To use the Probo Drupal plugin you must declare `plugin: Drupal` in your `.probo.yaml` file. The Drupal plugin's parameters can automate some steps specific to Drupal such as reverting features, running database updates, clearing caches, or performing other build configuration steps.
 
 The Probo Drupal plugin inherits all [Probo LAMP plugin](/plugins/lamp-plugin/) configuration options. This allows additional Probo Build steps in your `.probo.yaml` file to layer LAMP configuration options and commands on top of the Drupal site specific configuration.
 
@@ -13,41 +13,217 @@ See the <a href="#drupal-plugin-examples" title="Probo Drupal Plugin Examples">P
 
 ## Directory Configuration
 
-{: .table .table-striped .table-bordered}
-|-------------------------|-------------------------------------|
-|`makeFile`               | The name of the [Drush make file](http://www.drush.org/en/master/make/) to run to generate                             the install directory. Accepts a **string** value.                             |
-|`makeForceComplete`      | Whether to use the `--force-complete` option for drush `make`. Defaults to `true`. Accepts a **boolean** value. |
-|`makeArgs`               | A set of parameters to concatenate onto the drush `make` command. Accepts an **array** value. |
-|`profileName`            | The profile name used in creating a symlink to this directory if a Drush make file is                                  specified with the `makeFile` option and used to select the profile to install if the `runInstall`                             option is selected. Accepts a **string** value.                                |
-|`runInstall`             | If set, run `drush site-install` to perform a fresh install of the site using the                                      `profileName` as the install profile and allowing the `installArgs` option to configure the                                    install. Accepts a **boolean** value.                                            |
-|`installArgs`            | A set of parameters to concatenate onto the `drush site-install` command if the                                        `runInstall` option is set. Defaults to ''. Accepts a **string** value. |
-|`siteFolder`             | Specifies the site folder to use for this build (the folder within the Drupal `sites`                                  folder). Defaults to `default`. Accepts a **string** value.             |
-| `subDirectory`     |The path to your docroot if it is a subdirectory of your git repository. Accepts a **string** value. |
+{% option_list %}
+{% option %}
+### `makeFile` {string}
+The name of the [Drush make file](http://docs.drush.org/en/7.x/make/) to run to generate the install directory.
+{% details Example %}
+  {% highlight yaml%}
+    # Use a file in your docroot
+    steps:
+      - name: Specify make file
+        plugin: Drupal
+        makeFile: example.make
 
-## Database Configuration
+    # Use an uploaded asset
+    assets:
+      - probo-specific.make
+    steps:
+      - name: Specify make file
+        plugin: Drupal
+        makeFile: $ASSET_DIR/probo-specific.make
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
 
-{: .table .table-striped .table-bordered}
-|-------------------------|-------------------------------------|
-| `database`              |The name of the database to import if specified. Note that this database *must be added as                             an asset separately*. Accepts a **string** value. If you use this parameter, don't add the database with the shell plugin. Do not use the zip format for your compressed database. Use the gzip format.                           |
-| `databaseGzipped`       |Whether the database was sent gzipped and whether it should therefore be gunzipped before                               importing. Accepts a **boolean** value.                                         |
-| `databaseBzipped`       |Whether the database was sent bzipped and whether it should therefore be bunzipped before                               importing. Accepts a **boolean** value.                                         |
+{% option %}
+### `makeForceComplete` {boolean}
+Whether to use the `--force-complete` option for `drush make`. Defaults to `true`.
+{% details Example %}
+  {% highlight yaml%}
+    steps:
+      - name: Do not force make file completion
+        plugin: Drupal
+        makeForceComplete: false
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `makeArgs` {array}
+A set of parameters to concatenate onto the `drush make` command.
+{% details Example %}
+  {% highlight yaml%}
+
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `profileName` {string}
+The profile name used in creating a symlink to this directory if a Drush make file is specified with the [`makeFile`](#makefile-string) option. Used to select the profile to install if the [`runInstall`](#runinstall-boolean) option is selected.
+{% details Example %}
+  {% highlight yaml%}
+
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `runInstall` {boolean}
+If set, run `drush site-install` to perform a fresh install of the site using the [`profileName`](#profilename-string) as the install profile and allowing the [`installArgs`](#installargs-string) option to configure the install.
+{% details Example %}
+  {% highlight yaml%}
+
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `installArgs` {string}
+A set of parameters to concatenate onto the `drush site-install` command if the [`runInstall`](#runinstall-string) option is set. Defaults to ''.
+{% details Example %}
+  {% highlight yaml%}
+
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `siteFolder` {string}
+Specifies the site folder to use for this build (the folder within the Drupal `sites` folder). Defaults to `default`.
+{% details Example %}
+  {% highlight yaml%}
+    steps:
+      - name: Specify non-default site
+        plugin: Drupal
+        siteFolder: blog
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `subDirectory` {string}
+The path to your docroot if it is a subdirectory of your git repository.
+{% details Example %}
+  {% highlight yaml%}
+
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% endoption_list %}
 
 ## Settings.php Options
 
-{: .table .table-striped .table-bordered}
-|-------------------------|-------------------------------------|
-| `settingsRequireFile`      |A file to require at the end of settings.php. This option helps you to avoid checking settings.php into your repository. Accepts a **string** value.|
-| `settingsAppend`      |Specify a snippet, such as a variable, to append to the end of the settings.php file. Accepts a **string** value. |
+{% option_list %}
+
+{% option %}
+### `settingsRequireFile` {string}
+A file to require at the end of settings.php. This option helps you to avoid checking settings.php into your repository.
+{% details Example %}
+  {% highlight yaml%}
+    # Require checked in settings
+    steps:
+      - name: Require Probo-specific site settings
+        plugin: Drupal
+        settingsRequireFile: sites/default/probo-settings.php
+
+    # Use an uploaded asset
+    assets:
+      - probo-settings.php
+    steps:
+      - name: Require Probo-specific site settings
+        plugin: Drupal
+        settingsRequireFile: $ASSET_DIR/probo-settings.php
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `settingsAppend` {string}
+Specify a snippet, such as a variable, to append to the end of the settings.php file.
+{% details Example %}
+  {% highlight yaml%}
+    steps:
+      - name: Append to settings.php
+        plugin: Drupal
+        settingsAppend: |
+          $bar = 'baz';
+          $foo = 'stuff';
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+{% endoption_list %}
 
 ## Additional Options
+{% option_list %}
 
-{: .table .table-striped .table-bordered}
-|-------------------------|-------------------------------------|
-| `drupalVersion`       |Specifies which version of Drupal you are using so that the appropriate commands can be run. For example, if you specify "8" the `clearCaches` option will run `drush cache-rebuild`. Defaults to 7. Accepts the **integer** values 6, 7, or 8.        |
-| `databaseUpdates`     |Determines whether to run `drush updb` after the build is finished. Accepts a                                  **boolean** value.                                                                         |
-| `clearCaches`         |Whether to clear all caches using `drush cc all` after the build is finished. Your Drupal site must be version 7 or older to use this option. Defaults to                                           true. Accepts a **boolean** value.                                                 |
-| `revertFeatures`      |Whether to revert features using `drush fra` after the build is finished. To use this option, your site must have the [Features module](https://www.drupal.org/project/features) installed. Accepts a                             **boolean** value.                                                                        |
-|  `fileProxy`          |Installs and enables the [Stage File Proxy module](https://www.drupal.org/project/stage_file_proxy) to retrieve public and/or private files from another instance of the site such as production or development. Enter the protocol and fully qualified domain here, as in "https://example.com". Accepts a **string** value.                                      |
+{% option %}
+### `drupalVersion` {integer}
+Specifies which version of Drupal you are using so that the appropriate commands can be run. For example, if you specify "8" the [`clearCaches`](#clearcaches-boolean) option will run `drush cache-rebuild`. Defaults to 7. Accepts the integer values 6, 7, or 8.
+{% details Example %}
+  {% highlight yaml%}
+    steps:
+      - name: Set Drupal version
+        plugin: Drupal
+        drupalVersion: 8
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `databaseUpdates` {boolean}
+Determines whether to run `drush updb` after the build is finished.
+{% details Example %}
+  {% highlight yaml%}
+    steps:
+      - name: Run database updates
+        plugin: Drupal
+        databaseUpdates: true
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `clearCaches` {boolean}
+Whether to clear all caches using `drush cc all` after the build is finished. Pair with the [`drupalVersion`](#drupalversion-integer) option to ensure the proper command is run for your version of Drupal. Defaults to true.
+{% details Example %}
+  {% highlight yaml%}
+    steps:
+      - name: Clear caches
+        plugin: Drupal
+        clearCaches: true
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `revertFeatures` {boolean}
+Whether to revert features using `drush fra` after the build is finished. To use this option, your site must have the [Features module](https://www.drupal.org/project/features) installed.
+{% details Example %}
+  {% highlight yaml%}
+    steps:
+      - name: Revert features
+        plugin: Drupal
+        revertFeatures: true
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `fileProxy` {string}
+Installs and enables the [Stage File Proxy module](https://www.drupal.org/project/stage_file_proxy) to retrieve public and/or private files from another instance of the site such as production or development. Enter the protocol and fully qualified domain here.
+{% details Example %}
+  {% highlight yaml%}
+    steps:
+      - name: Proxy site files
+        plugin: Drupal
+        fileProxy: https://example.com
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+{% endoption_list %}
 
 <h2 id="drupal-plugin-examples">Probo Drupal Plugin Examples</h2>
 

--- a/docs/plugins/lamp-plugin.md
+++ b/docs/plugins/lamp-plugin.md
@@ -83,7 +83,7 @@ Whether the database was sent bzipped and whether it should therefore be bunzipp
 
 {% option %}
 ### `mysqlCnfOptions` {hash}
-A hash of MySQL configuration options, such as {option1: 'option1Value', option2: 'option2Value',}.
+A hash of MySQL configuration options.
 
 {% details Example %}
   {% highlight yaml%}
@@ -114,24 +114,31 @@ Whether to restart MySQL. If `mysqlCnfOptions` is set, MySQL will be restarted a
 
 ## PHP Configuration
 
-Probo builds have their own isolated `php.ini` files. Specific PHP options for your build can be modified using the `phpIniOptions` configuration option in  your `.probo.yaml` file. The `phpIniOptions` configuration option must be paired with a LAMPApp compatible [Probo Plugin](https://docs.probo.ci/plugins/) to set specific PHP settings within the plugin's steps.
-
-See the <a href="#lamp-plugin-examples" title="Probo LAMP Plugin Examples">Probo LAMP Plugin Examples</a> section below for YAML config examples that set custom `upload_max_filesize`, `post_max_size`, and `memory_limit` PHP settings values for a Probo Build using the Probo LAMPApp plugin, and [Probo Drupal plugin](/plugins/drupal-plugin/).
-
 {% option_list %}
 {% option %}
 ### `phpIniOptions` {hash}
-A hash of options, such as {option1: 'option1Value', option2: 'option2Value',}.
+Probo builds have their own isolated `php.ini` files. Specific PHP options for your build can be modified using the this configuration option.
+{% details Example %}
+  {% highlight yaml%}
+  steps:
+    - name: Configure PHP
+      plugin: LAMPApp
+      phpIniOptions:
+        upload_max_filesize: 25M
+        post_max_size: 25M
+        memory_limit: 256M
+  {% endhighlight %}
+{% enddetails %}
 {% endoption %}
 
 {% option %}
 ### `phpConstants` {hash}
-A hash of constants, such as {const1: 'const1Value', const2: 'const2Value',}. This will overwrite any other auto_prepend_file directives in your php.ini.
+A hash of PHP constants. This will overwrite any other `auto_prepend_file` directives in your php.ini.
 {% endoption %}
 
 {% option %}
 ### `phpMods` {array}
-An array of php5 modules to enable (should be installed via the `installPackages` option if needed).
+An array of PHP 5 modules to enable (should be installed via [`installPackages`](#installpackages-array) if needed).
 {% endoption %}
 {% endoption_list %}
 
@@ -140,12 +147,20 @@ An array of php5 modules to enable (should be installed via the `installPackages
 {% option_list %}
 {% option %}
 ### `apacheMods` {array}
-An array of apache modules to enable (should be installed via installPackages if needed).
+An array of Apache modules to enable (should be installed via [`installPackages`](#installpackages-array) if needed).
 {% endoption %}
 
 {% option %}
 ### `restartApache` {boolean}
-Whether to restart Apache. If phpIniOptions, phpConstants, phpMods, or apacheMods are set, Apache will be restarted automatically, so you probably won't need to use this.
+Whether to restart Apache. If `phpIniOptions`, `phpConstants`, `phpMods`, or `apacheMods` are set, Apache will be restarted automatically, so you probably won't need to use this.
+{% details Example %}
+  {% highlight yaml%}
+  steps:
+    - name: Restart Apache
+      plugin: LAMPApp
+      restartApache: true
+  {% endhighlight %}
+{% enddetails %}
 {% endoption %}
 {% endoption_list %}
 
@@ -155,27 +170,47 @@ Whether to restart Apache. If phpIniOptions, phpConstants, phpMods, or apacheMod
 {% option %}
 ### `subDirectory` {string}
 The directory of the actual web root (defaults to 'docroot').
+{% details Example %}
+  {% highlight yaml%}
+  steps:
+    - name: Configure web root
+      plugin: LAMPApp
+      subDirectory: $SRC_DIR/web
+  {% endhighlight %}
+{% enddetails %}
 {% endoption %}
 
 {% option %}
 ### `cliDefines` {hash}
-A hash of defines, such as {define1: 'define1Value', define2: 'define2Value',}.
+A hash of defines.
 {% endoption %}
 
 {% option %}
 ### `installPackages` {array}
-An array of additional packages to install.
+An array of packages to install in addition to those that come with the [Docker image](/build/images).
 {% endoption %}
 
 {% option %}
 ### `varnish` {hash}
-A hash of options to configure the Varnish HTTP cache. The options are `enabled`, a boolean that defaults to false and indicates whether or not to enable Varnish, and `pathToVcl`, a string that indicates the path to your Varnish configuration file relative to the container root.
+A hash of options to configure the Varnish HTTP cache.
+
+`enabled`: A boolean that indicates whether or not to enable Varnish. Defaults to false.
+
+`pathToVcl`: A string that indicates the path to your Varnish configuration file relative to the container root.
+{% details Example %}
+  {% highlight yaml%}
+  steps:
+    - name: Configure Varnish
+      plugin: LAMPApp
+      varnish:
+        enabled: true
+        pathToVcl: $SRC_DIR/config.vcl
+  {% endhighlight %}
+{% enddetails %}
 {% endoption %}
 {% endoption_list %}
 
 <h2 id="lamp-plugin-examples">Probo LAMP Plugin Examples</h2>
-
-**Note:** The `LAMPApp` plugin options are inherited by the Probo Drupal, Wordpress, and other Probo plugins.
 
 **Using the `LAMPApp` Plugin to Test a PHP/MySQL Based Application**
 

--- a/docs/plugins/lamp-plugin.md
+++ b/docs/plugins/lamp-plugin.md
@@ -133,11 +133,6 @@ Probo builds have their own isolated `php.ini` files. Specific PHP options for y
 
 {% option %}
 ### `phpConstants` {hash}
-A hash of PHP constants. This will overwrite any other `auto_prepend_file` directives in your php.ini.
-{% endoption %}
-
-{% option %}
-### `phpConstants` {hash}
 Define a hash of PHP Constants and they will be available in any PHP script you run in your Probo Build. This setting will overwrite any other `auto_prepend_file` directives in your php.ini.
 {% details Example %}
   {% highlight yaml%}

--- a/docs/plugins/lamp-plugin.md
+++ b/docs/plugins/lamp-plugin.md
@@ -16,14 +16,14 @@ The [Probo Drupal plugin](/plugins/drupal-plugin/), [Probo WordPress plugin](/pl
 ### `database` {string}
 The file name of the database to import if specified. Note that this database must be added to the assets array separately.
 {% details Example %}
-  {% highlight yaml%}
-  assets:
-    - mydb.sql.gz
-  steps:
-    - name: Import database
-      plugin: LAMPApp
-      database: mydb.sql.gz
-  {% endhighlight %}
+{% highlight yaml%}
+assets:
+  - mydb.sql.gz
+steps:
+  - name: Import database
+    plugin: LAMPApp
+    database: mydb.sql.gz
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -31,12 +31,12 @@ The file name of the database to import if specified. Note that this database mu
 ### `databaseName` {string}
 The name of the database to use.
 {% details Example %}
-  {% highlight yaml%}
-  steps:
-    - name: Set database name
-      plugin: LAMPApp
-      databaseName: mydb
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Set database name
+    plugin: LAMPApp
+    databaseName: mydb
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -44,12 +44,12 @@ The name of the database to use.
 ### `databaseUser` {string}
 The username of the database to use.
 {% details Example %}
-  {% highlight yaml%}
-  steps:
-    - name: Set database user
-      plugin: LAMPApp
-      databaseUser: mydbuser
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Set database user
+    plugin: LAMPApp
+    databaseUser: mydbuser
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -58,12 +58,12 @@ The username of the database to use.
 Whether the database was sent gzipped and whether it should therefore be gunzipped before importing.
 
 {% details Example %}
-  {% highlight yaml%}
-  steps:
-    - name: Unzip database
-      plugin: LAMPApp
-      databaseGzipped: true
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Unzip database
+    plugin: LAMPApp
+    databaseGzipped: true
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -72,12 +72,12 @@ Whether the database was sent gzipped and whether it should therefore be gunzipp
 Whether the database was sent bzipped and whether it should therefore be bunzipped before importing.
 
 {% details Example %}
-  {% highlight yaml%}
-  steps:
-    - name: Unzip database
-      plugin: LAMPApp
-      databaseBzipped: true
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Unzip database
+    plugin: LAMPApp
+    databaseBzipped: true
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -86,14 +86,14 @@ Whether the database was sent bzipped and whether it should therefore be bunzipp
 A hash of MySQL configuration options.
 
 {% details Example %}
-  {% highlight yaml%}
-  steps:
-    - name: Set MySQL options
-      plugin: LAMPApp
-      mysqlCnfOptions:
-        key_buffer_size: 16M
-        max_allowed_packet: 128M
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Set MySQL options
+    plugin: LAMPApp
+    mysqlCnfOptions:
+      key_buffer_size: 16M
+      max_allowed_packet: 128M
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -102,12 +102,12 @@ A hash of MySQL configuration options.
 Whether to restart MySQL. If `mysqlCnfOptions` is set, MySQL will be restarted automatically, so you probably won't need to use this.
 
 {% details Example %}
-  {% highlight yaml%}
-  steps:
-    - name: Restart MySQL
-      plugin: LAMPApp
-      restartMysql: true
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Restart MySQL
+    plugin: LAMPApp
+    restartMysql: true
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 {% endoption_list %}
@@ -119,15 +119,15 @@ Whether to restart MySQL. If `mysqlCnfOptions` is set, MySQL will be restarted a
 ### `phpIniOptions` {hash}
 Probo builds have their own isolated `php.ini` files. Specific PHP options for your build can be modified using the this configuration option.
 {% details Example %}
-  {% highlight yaml%}
-  steps:
-    - name: Configure PHP
-      plugin: LAMPApp
-      phpIniOptions:
-        upload_max_filesize: 25M
-        post_max_size: 25M
-        memory_limit: 256M
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Configure PHP
+    plugin: LAMPApp
+    phpIniOptions:
+      upload_max_filesize: 25M
+      post_max_size: 25M
+      memory_limit: 256M
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -135,36 +135,36 @@ Probo builds have their own isolated `php.ini` files. Specific PHP options for y
 ### `phpConstants` {hash}
 Define a hash of PHP Constants and they will be available in any PHP script you run in your Probo Build. This setting will overwrite any other `auto_prepend_file` directives in your php.ini.
 {% details Example %}
-  {% highlight yaml%}
-  steps:
-    - name: Install Drupal 7
-      plugin: Drupal
-      runInstall: true
-      profileName: standard
-      clearCaches: false
-      subDirectory: docroot
-      phpConstants:
-        DEVUSER: Developer
-        EMAIL: dev@example.com
-        constant_1: example_1
-        CONSTANT_2: example_2
-        _constant_3: example_3
-        _CONSTANT_4: example_4
-    - name: Test defined constants.
-      plugin: Script
-      script: |
-        cat <<EOT >> /var/www/html/constants-example.php
-        <?php
-          echo DEVUSER;
-          echo EMAIL;
-          echo constant_1;
-          echo CONSTANT_2;
-          echo _constant_3;
-          echo _CONSTANT_4;
-        ?>
-        EOT
-        echo "View defined constants at $BUILD_DOMAIN/constants-example.php"
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Install Drupal 7
+    plugin: Drupal
+    runInstall: true
+    profileName: standard
+    clearCaches: false
+    subDirectory: docroot
+    phpConstants:
+      DEVUSER: Developer
+      EMAIL: dev@example.com
+      constant_1: example_1
+      CONSTANT_2: example_2
+      _constant_3: example_3
+      _CONSTANT_4: example_4
+  - name: Test defined constants.
+    plugin: Script
+    script: |
+      cat <<EOT >> /var/www/html/constants-example.php
+      <?php
+        echo DEVUSER;
+        echo EMAIL;
+        echo constant_1;
+        echo CONSTANT_2;
+        echo _constant_3;
+        echo _CONSTANT_4;
+      ?>
+      EOT
+      echo "View defined constants at $BUILD_DOMAIN/constants-example.php"
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -186,12 +186,12 @@ An array of Apache modules to enable (should be installed via [`installPackages`
 ### `restartApache` {boolean}
 Whether to restart Apache. If `phpIniOptions`, `phpConstants`, `phpMods`, or `apacheMods` are set, Apache will be restarted automatically, so you probably won't need to use this.
 {% details Example %}
-  {% highlight yaml%}
-  steps:
-    - name: Restart Apache
-      plugin: LAMPApp
-      restartApache: true
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Restart Apache
+    plugin: LAMPApp
+    restartApache: true
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 {% endoption_list %}
@@ -203,12 +203,12 @@ Whether to restart Apache. If `phpIniOptions`, `phpConstants`, `phpMods`, or `ap
 ### `subDirectory` {string}
 The directory of the actual web root (defaults to 'docroot').
 {% details Example %}
-  {% highlight yaml%}
-  steps:
-    - name: Configure web root
-      plugin: LAMPApp
-      subDirectory: $SRC_DIR/web
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Configure web root
+    plugin: LAMPApp
+    subDirectory: $SRC_DIR/web
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 
@@ -230,14 +230,14 @@ A hash of options to configure the Varnish HTTP cache.
 
 `pathToVcl`: A string that indicates the path to your Varnish configuration file relative to the container root.
 {% details Example %}
-  {% highlight yaml%}
-  steps:
-    - name: Configure Varnish
-      plugin: LAMPApp
-      varnish:
-        enabled: true
-        pathToVcl: $SRC_DIR/config.vcl
-  {% endhighlight %}
+{% highlight yaml%}
+steps:
+  - name: Configure Varnish
+    plugin: LAMPApp
+    varnish:
+      enabled: true
+      pathToVcl: $SRC_DIR/config.vcl
+{% endhighlight %}
 {% enddetails %}
 {% endoption %}
 {% endoption_list %}

--- a/docs/plugins/lamp-plugin.md
+++ b/docs/plugins/lamp-plugin.md
@@ -224,7 +224,7 @@ A hash of defines.
 
 {% option %}
 ### `installPackages` {array}
-An array of packages to install in addition to those that come with the [Docker image](/build/images).
+An array of packages to install in addition to those that come with the [Docker image](/build/images) in use.
 {% endoption %}
 
 {% option %}
@@ -247,7 +247,7 @@ A hash of options to configure the Varnish HTTP cache.
 {% endoption %}
 {% endoption_list %}
 
-<h2 id="lamp-plugin-examples">Probo LAMP Plugin Examples</h2>
+## Probo LAMP Plugin Example Recipes
 
 **Using the `LAMPApp` Plugin to Test a PHP/MySQL Based Application**
 

--- a/docs/plugins/lamp-plugin.md
+++ b/docs/plugins/lamp-plugin.md
@@ -11,15 +11,106 @@ The [Probo Drupal plugin](/plugins/drupal-plugin/), [Probo WordPress plugin](/pl
 
 ## Database Configuration
 
-{: .table .table-striped .table-bordered}
-|---------|----------------------------|
-| `database` | The file name of the database to import if specified. Note that this database *must be added to the assets array separately*. Accepts a **string** value. |
-| `databaseName` | The name of the database to use. Accepts a **string** value. |
-| `databaseUser` | The username of the database to use. Accepts a **string** value. |
-| `databaseGzipped` | Whether the database was sent gzipped and whether it should therefore be gunzipped before importing. Accepts a **boolean** value. |
-| `databaseBzipped` | Whether the database was sent bzipped and whether it should therefore be bunzipped before importing. Accepts a **boolean** value. |
-| `mysqlCnfOptions` | A hash of MySQL configuration options, such as {option1: 'option1Value', option2: 'option2Value',}. Accepts a **hash** value. |
-| `restartMysql` | Whether to restart MySQL. If `mysqlCnfOptions` is set, MySQL will be restarted automatically, so you probably won't need to use this. Accepts a **boolean** value. |
+{% option_list %}
+{% option %}
+### `database` {string}
+The file name of the database to import if specified. Note that this database must be added to the assets array separately.
+{% details Example %}
+  {% highlight yaml%}
+  assets:
+    - mydb.sql.gz
+  steps:
+    - name: Import database
+      plugin: LAMPApp
+      database: mydb.sql.gz
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `databaseName` {string}
+The name of the database to use.
+{% details Example %}
+  {% highlight yaml%}
+  steps:
+    - name: Set database name
+      plugin: LAMPApp
+      databaseName: mydb
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `databaseUser` {string}
+The username of the database to use.
+{% details Example %}
+  {% highlight yaml%}
+  steps:
+    - name: Set database user
+      plugin: LAMPApp
+      databaseUser: mydbuser
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `databaseGzipped` {boolean}
+Whether the database was sent gzipped and whether it should therefore be gunzipped before importing.
+
+{% details Example %}
+  {% highlight yaml%}
+  steps:
+    - name: Unzip database
+      plugin: LAMPApp
+      databaseGzipped: true
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `databaseBzipped` {boolean}
+Whether the database was sent bzipped and whether it should therefore be bunzipped before importing.
+
+{% details Example %}
+  {% highlight yaml%}
+  steps:
+    - name: Unzip database
+      plugin: LAMPApp
+      databaseBzipped: true
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `mysqlCnfOptions` {hash}
+A hash of MySQL configuration options, such as {option1: 'option1Value', option2: 'option2Value',}.
+
+{% details Example %}
+  {% highlight yaml%}
+  steps:
+    - name: Set MySQL options
+      plugin: LAMPApp
+      mysqlCnfOptions:
+        key_buffer_size: 16M
+        max_allowed_packet: 128M
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `restartMysql` {boolean}
+Whether to restart MySQL. If `mysqlCnfOptions` is set, MySQL will be restarted automatically, so you probably won't need to use this.
+
+{% details Example %}
+  {% highlight yaml%}
+  steps:
+    - name: Restart MySQL
+      plugin: LAMPApp
+      restartMysql: true
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+{% endoption_list %}
 
 ## PHP Configuration
 
@@ -27,27 +118,60 @@ Probo builds have their own isolated `php.ini` files. Specific PHP options for y
 
 See the <a href="#lamp-plugin-examples" title="Probo LAMP Plugin Examples">Probo LAMP Plugin Examples</a> section below for YAML config examples that set custom `upload_max_filesize`, `post_max_size`, and `memory_limit` PHP settings values for a Probo Build using the Probo LAMPApp plugin, and [Probo Drupal plugin](/plugins/drupal-plugin/).
 
-{: .table .table-striped .table-bordered}
-|---------|----------------------------|
-| `phpIniOptions` | A hash of options for all, apache2, and/or cli, such as {all: option1: 'option1Value', option2: 'option2Value'}. Accepts a **hash** value. |
-| `phpConstants` | A hash of constants, such as {const1: 'const1Value', const2: 'const2Value',}. This will overwrite any other auto_prepend_file directives in your php.ini. Accepts a **hash** value. |
-| `phpMods` | An array of php5 modules to enable (should be installed via the `installPackages` option if needed). Accepts an **array** value. |
+{% option_list %}
+{% option %}
+### `phpIniOptions` {hash}
+A hash of options, such as {option1: 'option1Value', option2: 'option2Value',}.
+{% endoption %}
+
+{% option %}
+### `phpConstants` {hash}
+A hash of constants, such as {const1: 'const1Value', const2: 'const2Value',}. This will overwrite any other auto_prepend_file directives in your php.ini.
+{% endoption %}
+
+{% option %}
+### `phpMods` {array}
+An array of php5 modules to enable (should be installed via the `installPackages` option if needed).
+{% endoption %}
+{% endoption_list %}
 
 ## Apache Configuration
 
-{: .table .table-striped .table-bordered}
-|---------|----------------------------|
-| `apacheMods` | An array of apache modules to enable (should be installed via installPackages if needed). Accepts an **array** value. |
-| `restartApache` | Whether to restart Apache. If phpIniOptions, phpConstants, phpMods, or apacheMods are set, Apache will be restarted automatically, so you probably won't need to use this. Accepts a **boolean** value. |
+{% option_list %}
+{% option %}
+### `apacheMods` {array}
+An array of apache modules to enable (should be installed via installPackages if needed).
+{% endoption %}
+
+{% option %}
+### `restartApache` {boolean}
+Whether to restart Apache. If phpIniOptions, phpConstants, phpMods, or apacheMods are set, Apache will be restarted automatically, so you probably won't need to use this.
+{% endoption %}
+{% endoption_list %}
 
 ## Additional Options
 
-{: .table .table-striped .table-bordered}
-|---------|----------------------------|
-| `subDirectory` | The directory of the actual web root (defaults to 'docroot'). Accepts a **string** value. |
-| `cliDefines` | A hash of defines, such as {define1: 'define1Value', define2: 'define2Value',}. Accepts a **hash** value. |
-| `installPackages` | An array of additional packages to install. Accepts an **array** value. |
-| `varnish` | A hash of options to configure the Varnish HTTP cache. The options are `enabled`, a boolean that defaults to false and indicates whether or not to enable Varnish, and `pathToVcl`, a string that indicates the path to your Varnish configuration file relative to the container root.
+{% option_list %}
+{% option %}
+### `subDirectory` {string}
+The directory of the actual web root (defaults to 'docroot').
+{% endoption %}
+
+{% option %}
+### `cliDefines` {hash}
+A hash of defines, such as {define1: 'define1Value', define2: 'define2Value',}.
+{% endoption %}
+
+{% option %}
+### `installPackages` {array}
+An array of additional packages to install.
+{% endoption %}
+
+{% option %}
+### `varnish` {hash}
+A hash of options to configure the Varnish HTTP cache. The options are `enabled`, a boolean that defaults to false and indicates whether or not to enable Varnish, and `pathToVcl`, a string that indicates the path to your Varnish configuration file relative to the container root.
+{% endoption %}
+{% endoption_list %}
 
 <h2 id="lamp-plugin-examples">Probo LAMP Plugin Examples</h2>
 

--- a/docs/plugins/lamp-plugin.md
+++ b/docs/plugins/lamp-plugin.md
@@ -168,10 +168,6 @@ steps:
 {% enddetails %}
 {% endoption %}
 
-{% option %}
-### `phpMods` {array}
-An array of PHP 5 modules to enable (should be installed via [`installPackages`](#installpackages-array) if needed).
-{% endoption %}
 {% endoption_list %}
 
 ## Apache Configuration

--- a/docs/plugins/lamp-plugin.md
+++ b/docs/plugins/lamp-plugin.md
@@ -137,6 +137,43 @@ A hash of PHP constants. This will overwrite any other `auto_prepend_file` direc
 {% endoption %}
 
 {% option %}
+### `phpConstants` {hash}
+Define a hash of PHP Constants and they will be available in any PHP script you run in your Probo Build. This setting will overwrite any other `auto_prepend_file` directives in your php.ini.
+{% details Example %}
+  {% highlight yaml%}
+  steps:
+    - name: Install Drupal 7
+      plugin: Drupal
+      runInstall: true
+      profileName: standard
+      clearCaches: false
+      subDirectory: docroot
+      phpConstants:
+        DEVUSER: Developer
+        EMAIL: dev@example.com
+        constant_1: example_1
+        CONSTANT_2: example_2
+        _constant_3: example_3
+        _CONSTANT_4: example_4
+    - name: Test defined constants.
+      plugin: Script
+      script: |
+        cat <<EOT >> /var/www/html/constants-example.php
+        <?php
+          echo DEVUSER;
+          echo EMAIL;
+          echo constant_1;
+          echo CONSTANT_2;
+          echo _constant_3;
+          echo _CONSTANT_4;
+        ?>
+        EOT
+        echo "View defined constants at $BUILD_DOMAIN/constants-example.php"
+  {% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
 ### `phpMods` {array}
 An array of PHP 5 modules to enable (should be installed via [`installPackages`](#installpackages-array) if needed).
 {% endoption %}

--- a/docs/plugins/wordpress-plugin.md
+++ b/docs/plugins/wordpress-plugin.md
@@ -12,19 +12,78 @@ WordPress core and plugins generally prefer absolute URLs for links and images i
 
 ## Domain/URL Configuration
 
-{: .table .table-striped .table-bordered}
-|------------------------|-------|
-| wpUrl | The URL of the original site as stored in the database. This is replaced by the Probo URL in the database. Accepts a **string** value. |
-| wpHome | The homepage URL of the original site (including the domain). This is replaced by the Probo URL in the database. Accepts a **string** value. |
+{% option_list %}
+{% option %}
+### `wpUrl` {string}
+The URL of the original site as stored in the database. This is replaced by the Probo URL in the database.
+{% details Example %}
+{% highlight yaml%}
+steps:
+  - name: Identify site URL
+    plugin: WordPressApp
+    wpUrl: http://www.example.com
+{% endhighlight %}
+{% enddetails %}
+{% endoption %}
 
+{% option %}
+### `wpHome` {string}
+The homepage URL of the original site (including the domain). This is replaced by the Probo URL in the database.
+{% details Example %}
+{% highlight yaml%}
+steps:
+  - name: Identify homepage URL
+    plugin: WordPressApp
+    wpHome: http://www.example.com
+{% endhighlight %}
+{% enddetails %}
+{% endoption %}
+{% endoption_list %}
 
 ## Database Configuration
 
-{: .table .table-striped .table-bordered}
-|------------------------|-------|
-| database | The filename of the database to import if specified. **Note that this database must be added to the Assets section separately.** Accepts a **string** value. |
-| databaseName   | The name of the database. Accepts a **string** value. Defaults to `wordpress`. |
-| databaseGzipped| Whether the database was sent gzipped and whether it should therefore be gunzipped before importing. Accepts a **boolean** value. |
+{% option_list %}
+{% option %}
+### `database` {string}
+The filename of the database to import if specified. **Note that this database must be added to the Assets section separately.**
+{% details Example %}
+{% highlight yaml%}
+assets:
+  - mydb.sql.gz
+steps:
+  - name: Import database
+    plugin: WordPressApp
+    database: mydb.sql.gz
+{% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `databaseName` {string}
+The name of the database. Defaults to `wordpress`.
+{% details Example %}
+{% highlight yaml%}
+steps:
+  - name: Set database name
+    plugin: WordPressApp
+    databaseName: mydb
+{% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `databaseGzipped` {boolean}
+Whether the database was sent gzipped and whether it should therefore be gunzipped before importing.
+{% details Example %}
+{% highlight yaml%}
+steps:
+  - name: Unzip database
+    plugin: WordPressApp
+    databaseGzipped: true
+{% endhighlight %}
+{% enddetails %}
+{% endoption %}
+{% endoption_list %}
 
 ### Known Issues
 
@@ -32,9 +91,9 @@ WordPress core and plugins generally prefer absolute URLs for links and images i
 Currenty in Wordpress 4.8.x, the MySQL database collation can be in COLLATION format `utf8mb4_unicode_520_ci`. This format is unsupported by our current docker images depending on your site's MySQL Server version. If you exported your DB from MySQL 5.6 or higher, you might receive the following error:
 
     ERROR 1273 (HY000) at line 25: Unknown collation: 'utf8mb4_unicode_520_ci'
-    
+
 You will need to modify your exported `sitename.sql` file to allow your exported DB to import properly on Probo's current Docker images.
-    
+
 ##### Workaround:
 
 Find and replace `utf8mb4_unicode_520_ci` with `utf8mb4_unicode_ci` in your exported `sitename.sql` file. Then, upload this modified file as a Probo Asset, and set this DB as an asset in  your `.probo.yaml` file. This will no longer be neccessary once we create docker images that support the newer `utf8mb4_unicode_520_ci` format.
@@ -67,14 +126,48 @@ Update `wp-cli` in your `.probo.yaml` steps.
         flushCaches: true
     {% endhighlight %}
 
-
 ## Additional Options
 
-{: .table .table-striped .table-bordered}
-|--------------------|-------|
-| subDirectory | The directory of the actual web root. Accepts a **string** value. Defaults to `docroot`. |
-| flushCaches | Whether or not to flush the cache. Accepts a **boolean** value. Defaults to `true`. |
-| updatePlugins | Whether or not to attempt to update any WordPress plugins to their latest versions. Accepts a **boolean** value. Defaults to `false`. |
+{% option_list %}
+{% option %}
+### `subDirectory` {string}
+The directory of the actual web root. Defaults to `docroot`.
+{% details Example %}
+{% highlight yaml%}
+steps:
+  - name: Configure web root
+    plugin: WordPressApp
+    subDirectory: $SRC_DIR/web
+{% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `flushCaches` {boolean}
+Whether or not to flush the cache. Defaults to `true`.
+{% details Example %}
+{% highlight yaml%}
+steps:
+  - name: Flush caches
+    plugin: WordPressApp
+    flushCaches: true
+{% endhighlight %}
+{% enddetails %}
+{% endoption %}
+
+{% option %}
+### `updatePlugins` {boolean}
+Whether or not to attempt to update any WordPress plugins to their latest versions. Defaults to `false`.
+{% details Example %}
+{% highlight yaml%}
+steps:
+  - name: Update plugins
+    plugin: WordPressApp
+    updatePlugins: true
+{% endhighlight %}
+{% enddetails %}
+{% endoption %}
+{% endoption_list %}
 
 ## Example
 


### PR DESCRIPTION
I'm unhappy with the Plugin option documentation, and a big source of the trouble comes from the tables we used. They limit how we can present information, and make it impossible to nicely provide an example for each option with the rest of its documentation.

The goal of this branch is to:
- Give us more flexibility in how we can present information about plugin options
- Make it possible to provide examples with the rest of an option's documentation