### PR TITLE
Adding additional LAMP Plugin examples.

### DIFF
--- a/docs/plugins/lamp-plugin.md
+++ b/docs/plugins/lamp-plugin.md
@@ -227,7 +227,24 @@ A hash of defines.
 
 {% option %}
 ### `installPackages` {array}
-An array of packages to install in addition to those that come with the [Docker image](/build/images) in use.
+Install additional apt packages in your build on top of the apt packages that come installed on all [Probo Docker images](/build/images).
+{% details Example %}
+{% highlight yaml%}
+steps:
+  - name: Install Drupal 7 with optipng package.
+    plugin: Drupal
+    runInstall: true
+    profileName: standard
+    clearCaches: false
+    subDirectory: docroot
+    installPackages:
+      - optipng
+  - name: Check if optipng package is installed.
+    plugin: Script
+    script: |
+      dpkg -l optipng
+{% endhighlight %}
+{% enddetails %}
 {% endoption %}
 
 {% option %}

--- a/docs/plugins/lamp-plugin.md
+++ b/docs/plugins/lamp-plugin.md
@@ -137,12 +137,8 @@ Define a hash of PHP Constants and they will be available in any PHP script you 
 {% details Example %}
 {% highlight yaml%}
 steps:
-  - name: Install Drupal 7
-    plugin: Drupal
-    runInstall: true
-    profileName: standard
-    clearCaches: false
-    subDirectory: docroot
+  - name: Setup phpConstants for LAMPApp.
+    plugin: LAMPApp
     phpConstants:
       DEVUSER: Developer
       EMAIL: dev@example.com
@@ -178,12 +174,8 @@ steps:
 An array of Apache modules to enable (should be installed via [`installPackages`](#installpackages-array) if needed).
 {% details Example %}
 {% highlight yaml%}
-- name: Install Drupal 7 with LDAP Apache Module installed.
-    plugin: Drupal
-    runInstall: true
-    profileName: standard
-    clearCaches: false
-    subDirectory: docroot
+- name: Install ldap in apacheMods.
+    plugin: LAMPApp
     apacheMods:
       - ldap
 {% endhighlight %}
@@ -223,6 +215,15 @@ steps:
 {% option %}
 ### `cliDefines` {hash}
 A hash of defines.
+{% details Example %}
+{% highlight yaml%}
+steps:
+  - name: Add Defines_1 CLI variable.
+    plugin: LAMPApp
+    cliDefines:
+      Defines_1: example1
+{% endhighlight %}
+{% enddetails %}
 {% endoption %}
 
 {% option %}
@@ -231,12 +232,8 @@ Install additional apt packages in your build on top of the apt packages that co
 {% details Example %}
 {% highlight yaml%}
 steps:
-  - name: Install Drupal 7 with optipng package.
-    plugin: Drupal
-    runInstall: true
-    profileName: standard
-    clearCaches: false
-    subDirectory: docroot
+  - name: Install optipng in LAMPApp.
+    plugin: LAMPApp
     installPackages:
       - optipng
   - name: Check if optipng package is installed.

--- a/docs/plugins/lamp-plugin.md
+++ b/docs/plugins/lamp-plugin.md
@@ -177,6 +177,18 @@ steps:
 ### `apacheMods` {array}
 An array of Apache modules to enable (should be installed via [`installPackages`](#installpackages-array) if needed).
 {% endoption %}
+{% details Example %}
+{% highlight yaml%}
+- name: Install Drupal 7 with LDAP Apache Module installed.
+    plugin: Drupal
+    runInstall: true
+    profileName: standard
+    clearCaches: false
+    subDirectory: docroot
+    apacheMods:
+      - ldap
+{% endhighlight %}
+{% enddetails %}
 
 {% option %}
 ### `restartApache` {boolean}

--- a/docs/plugins/lamp-plugin.md
+++ b/docs/plugins/lamp-plugin.md
@@ -176,7 +176,6 @@ steps:
 {% option %}
 ### `apacheMods` {array}
 An array of Apache modules to enable (should be installed via [`installPackages`](#installpackages-array) if needed).
-{% endoption %}
 {% details Example %}
 {% highlight yaml%}
 - name: Install Drupal 7 with LDAP Apache Module installed.
@@ -189,6 +188,7 @@ An array of Apache modules to enable (should be installed via [`installPackages`
       - ldap
 {% endhighlight %}
 {% enddetails %}
+{% endoption %}
 
 {% option %}
 ### `restartApache` {boolean}


### PR DESCRIPTION
Adding the rest of the LAMP plugin settings that I have tested.

- `apacheMods` has been added.
- `installPackages` has been added.
- `cliDefines` is a bit odd because apparently if you try to use one of the variables in a Script command in a lower step it won't work. I'm leaving this out for now until we can figure out how this is really supposed to work, as it doesn't seem very useful as it stands.
  - I feel we may want to move the cliDefines setting to the Script plugin and let it be available to the LAMP Plugin that way.