### PR TITLE
Better section heading and explain use of set -e to fail a step

### DIFF
--- a/docs/plugins/script-plugin.md
+++ b/docs/plugins/script-plugin.md
@@ -19,9 +19,9 @@ Instead of `command`, the Probo Script plugin requires a parameter for `script`.
 {% endif %}
 {% endfor %}
 
-Currently a [Probo Build Step](/build/steps/) will pass or fail based on the exit code of last command run in that particular step. Be sure to put any automated tests you want to ensure return the exit code you desire as the last command in a [Probo Script Plugin](plugins/script-plugin/) step or in a separate Probo Build Step. False positives will occur if a command exits 1 after automated tests such as behat may actually be failing in the Probo Build Step. This same execution ordering should be noted on Probo plugins that extend the Probo Script Plugin like the [Probo LAMP Plugin](/plugins/lamp-plugin/), the [Probo Drupal Plugin](/plugins/drupal-plugin/), and the [Probo Wordpress Plugin](/plugins/wordpress-plugin/).
+Currently a [Probo Build Step](/build/steps/) will pass or fail based on the exit code of last command run in that particular step. Be sure to put any automated tests you want to ensure return the exit code you desire as the last command in a [Probo Script Plugin](plugins/script-plugin/) step or in a separate Probo Build Step. False positives will occur if a command exits 1 after automated tests such as behat may actually be failing in the Probo Build Step. You can force a step to exit and fail on the first non-zero exit code using bash `set -e` inside of the Script. This same execution ordering should be noted on Probo plugins that extend the Probo Script Plugin like the [Probo LAMP Plugin](/plugins/lamp-plugin/), the [Probo Drupal Plugin](/plugins/drupal-plugin/), and the [Probo Wordpress Plugin](/plugins/wordpress-plugin/).
 
-### Developing on a site with a database:
+### Using the Script plugin with 2 styles of strings:
 
 {% for example in site.examples %}
 {% if example.uid == 'script_site_with_database' %}


### PR DESCRIPTION
I found this solution to getting a step to fail.

In fixing it I noticed the section heading for the 2 examples was some leftover copy/pasta.